### PR TITLE
feat: 支持png、jpeg图片进行裁剪

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.0-beta.8 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -506,6 +506,8 @@ github.com/nanmu42/etherscan-api v1.7.0 h1:b50tGqSRj8+fcrQAuttdJiY24hprVSasGwLDN
 github.com/nanmu42/etherscan-api v1.7.0/go.mod h1:CmsVjoXu6wovJhK0WfLhdmQerFqVFKypHdSgjfM43H8=
 github.com/naoina/go-stringutil v0.1.0/go.mod h1:XJ2SJL9jCtBh+P9q5btrd/Ylo8XwT/h1USek5+NqSA0=
 github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416/go.mod h1:NBIhNtsFMo3G2szEBne+bO4gS192HuIYRqfvOWb4i1E=
+github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
+github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=

--- a/internal/apiserver/blob/v1/controller.go
+++ b/internal/apiserver/blob/v1/controller.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/waite-lee/nftserver/pkg/blob"
 	"github.com/waite-lee/nftserver/pkg/mvc"
 )
 
@@ -24,11 +25,21 @@ func (c *BlobController) Get(ctx *gin.Context) {
 	}
 	key = strings.TrimLeft(key, "/")
 	service := BuildBlobServiceV1()
-	reader, err := service.Get(key)
+	reader, err := service.Get(key, parseProcess(ctx))
 	if err != nil {
 		mvc.Error(ctx, err)
 		return
 	}
-	contentType := http.DetectContentType(reader.Content[:512])
+	contentType := "application/octet-stream"
+	if len(reader.Content) >= 512 {
+		contentType = http.DetectContentType(reader.Content[:512])
+	}
 	ctx.Data(200, contentType, reader.Content)
+}
+
+func parseProcess(ctx *gin.Context) *blob.Process {
+	process := blob.Process{}
+	process.Width = mvc.QueryInt(ctx, "w")
+	process.Height = mvc.QueryInt(ctx, "h")
+	return &process
 }

--- a/internal/apiserver/blob/v1/service.go
+++ b/internal/apiserver/blob/v1/service.go
@@ -12,6 +12,6 @@ func NewBlobService(store blob.BlobStore) *BlobService {
 	}
 }
 
-func (srv *BlobService) Get(key string) (*blob.BlobReader, error) {
-	return srv.store.Read(&key)
+func (srv *BlobService) Get(key string, process *blob.Process) (*blob.BlobReader, error) {
+	return srv.store.Read(&key, process)
 }

--- a/pkg/blob/main.go
+++ b/pkg/blob/main.go
@@ -10,5 +10,5 @@ type BlobStore interface {
 	// GetString returns the string value of the given key.
 	Save(key *string, content *[]byte, overwrite bool) error
 	Exists(key *string) bool
-	Read(key *string) (*BlobReader, error)
+	Read(key *string, process *Process) (*BlobReader, error)
 }

--- a/pkg/blob/process.go
+++ b/pkg/blob/process.go
@@ -1,0 +1,7 @@
+package blob
+
+type Process struct {
+	Width  int
+	Height int
+	Args   map[string]string
+}

--- a/pkg/mvc/page.go
+++ b/pkg/mvc/page.go
@@ -7,15 +7,23 @@ import (
 )
 
 func PageQuery(ctx *gin.Context) (int, int) {
-	page := parseInt(ctx.Query("page"), 1)
-	pageSize := parseInt(ctx.Query("page_size"), 10)
+	page := ParseIntDefault(ctx.Query("page"), 1)
+	pageSize := ParseIntDefault(ctx.Query("page_size"), 10)
 	return page, pageSize
 }
 
-func parseInt(v string, defaultValue int) int {
+func ParseIntDefault(v string, defaultValue int) int {
 	i, err := strconv.Atoi(v)
 	if err != nil {
 		return defaultValue
 	}
 	return i
+}
+
+func ParseInt(v string) int {
+	return ParseIntDefault(v, 0)
+}
+
+func QueryInt(ctx *gin.Context, name string) int {
+	return ParseInt(ctx.Query(name))
 }


### PR DESCRIPTION
BlobStore支持对png、jpeg的图片进行裁剪，#1

通过

``` golang
Read(key *string, process *Process) (*BlobReader, error)
```
process 传递相关参数

``` golang 
type Process struct {
	Width  int
	Height int
	Args   map[string]string
}
```

Width 和 Height 必须都大于0才生效

目前只实现了文件系统
- [x] File system provider